### PR TITLE
Support Emscripten build without Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A template for kick starting a Cloudflare worker project with emscripten
 [`build.js`](build.js) holds the command we use to call emscripten.  
 [`webpack.config.js`](webpack.config.js) holds the webpack config we use to bundle the emscripten output together with your script.
 
-This template requires [docker](https://docs.docker.com/install/) for providing the emscripten build environment. While we believe this provides the best developer experience, if you wish to not use docker you can delete the check for docker and the docker parts of the build command in `build.js`. Note this means you must have emscripten installed on your machine.
+To compile your C code to WebAssembly, this template uses [Emscripten](https://emscripten.org/docs/getting_started/downloads.html) if it is installed on your machine. Otherwise, it requires [docker](https://docs.docker.com/install/) for providing the emscripten build environment.
 
 #### Wrangler
 

--- a/build.js
+++ b/build.js
@@ -1,13 +1,29 @@
 var $ = require('shelljs')
 
-if (!$.which('docker')) {
-  $.echo(
-    'This template requires docker to work. Please install docker and try again.',
-  )
-  $.exit(1)
+// Emscripten command:
+var cmd = `
+  emcc -O2 -s WASM=1 \
+    ./src/main.c \
+    -s EXTRA_EXPORTED_RUNTIME_METHODS='["cwrap", "setValue"]' \
+    -s ALLOW_MEMORY_GROWTH=1 \
+    -s DYNAMIC_EXECUTION=0 \
+    -s TEXTDECODER=0 \
+    -s MODULARIZE=1 \
+    -s ENVIRONMENT="web" \
+    -s EXPORT_NAME="emscripten" \
+    --pre-js "./pre.js" \
+    -o ./build/module.js
+`
+
+// If user doesn't have Emscripten installed locally, try launching it through docker.
+if(!$.which('emcc')) {
+  cmd = `docker run --rm -v $(pwd):/src trzeci/emscripten ${cmd}`
+
+  if (!$.which('docker')) {
+    $.echo('This template requires docker to work. Please install docker and try again.',)
+    $.exit(1)
+  }
 }
 
 $.mkdir('-p', 'build')
-$.exec(
-  'docker run --rm -v $(pwd):/src trzeci/emscripten emcc -O2 -s WASM=1 -s EXTRA_EXPORTED_RUNTIME_METHODS=\'["cwrap", "setValue"]\' -s ALLOW_MEMORY_GROWTH=1 -s DYNAMIC_EXECUTION=0 -s TEXTDECODER=0 -s MODULARIZE=1 -s ENVIRONMENT=\'web\' -s EXPORT_NAME="emscripten" --pre-js \'./pre.js\' -o ./build/module.js ./src/main.c',
-)
+$.exec(cmd)

--- a/build.js
+++ b/build.js
@@ -1,18 +1,18 @@
 var $ = require('shelljs')
 
 // Emscripten command:
-var cmd = `
-  emcc -O2 -s WASM=1 \
-    ./src/main.c \
-    -s EXTRA_EXPORTED_RUNTIME_METHODS='["cwrap", "setValue"]' \
-    -s ALLOW_MEMORY_GROWTH=1 \
-    -s DYNAMIC_EXECUTION=0 \
-    -s TEXTDECODER=0 \
-    -s MODULARIZE=1 \
-    -s ENVIRONMENT="web" \
-    -s EXPORT_NAME="emscripten" \
-    --pre-js "./pre.js" \
-    -o ./build/module.js
+var cmd = `emcc -O2 \
+  -s WASM=1 \
+  -s EXTRA_EXPORTED_RUNTIME_METHODS='["cwrap", "setValue"]' \
+  -s ALLOW_MEMORY_GROWTH=1 \
+  -s DYNAMIC_EXECUTION=0 \
+  -s TEXTDECODER=0 \
+  -s MODULARIZE=1 \
+  -s ENVIRONMENT="web" \
+  -s EXPORT_NAME="emscripten" \
+  --pre-js "./pre.js" \
+  -o ./build/module.js \
+  ./src/main.c
 `
 
 // If user doesn't have Emscripten installed locally, try launching it through docker.


### PR DESCRIPTION
First, thank you for this template! I've found it really useful in my projects.

This PR includes small changes to `build.js` so that it uses Emscripten if the user already has it installed on their computer, and otherwise it tries using Docker. It fails out if neither Emscripten nor Docker were found.

The small benefit from this is to save the user from having to comment out the docker parts of `build.js` for a new project if they already have Emscripten :D 
